### PR TITLE
New CLI command: wcb (watch clipboard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ As explained in
 ## Setup
 
 1. Install Clojure as per [this guide](https://clojure.org/guides/getting_started)
+   1. This project uses the new Clojure CLI (`clj`) and
+      [tools.deps](https://clojure.org/guides/deps_and_cli), both of which are installed by
+      [the new official Clojure installers](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools)
+      released alongside Clojure 1.9. If you’ve been working with Clojure for awhile, you might
+      not have these tools installed. Try `which clj` to check, and if that prints a blank line,
+      try running the appropriate
+      [installer](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).
 2. Clone this repo
 3. `cd` into the repo
 4. To install the dependencies, run: `clojure -R:dev -e '(println "deps installed!")'`
@@ -27,13 +34,7 @@ As explained in
 ## Basic Usage
 
 1. Have `clj` installed ([guide](https://clojure.org/guides/getting_started))
-1. In your shell: `clj`
-1. In the REPL:
-   1. `(use 'fc4c.repl)`
-   1. Read the printed descriptions of `pcb` and `wcb`
-   1. Run either `(pcb)` or `(wcb)`
-
-(There will soon be an option to run `wcb` directly from the command-line.)
+1. Run in your shell: `./wcb`
 
 ## Full Usage Workflow
 
@@ -41,9 +42,7 @@ As explained in [The Authoring Workflow](https://fundingcircle.github.io/fc4-fra
 [the FC4 Methodology](https://fundingcircle.github.io/fc4-framework/methodology/):
 
 > 1. In your text editor: either create a new diagram source file or open an existing diagram source file
-> 1. In a terminal, in your FC4C working dir:
->    1. Open a Clojure REPL with `clj`
->    1. Evaluate `(use 'fc4c.repl')` then `(wcb)`
+> 1. In a terminal, in your FC4C working dir, run `./wcb`
 >    1. This starts a background process that will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
 > 1. In your text editor, add/revise elements and relationships, then select-all and cut the diagram source from your editor into your system clipboard.
 >    1. This will cause FC4C to process the contents of your clipboard.

--- a/deps.edn
+++ b/deps.edn
@@ -21,4 +21,6 @@
                                      ;; See https://github.com/cognitect-labs/test-runner/pull/12
                                      com.cognitect/test-runner  {:git/url "https://github.com/Olical/test-runner"
                                                                  :sha "7c4f5bd4987ec514889c7cd7e3d13f4ef95f256b"}}
-                       :main-opts   ["-m" "cognitect.test-runner"]}}}
+                       :main-opts   ["-m" "cognitect.test-runner"]}
+           :wcb ;; wcb = “watch clipboard”
+           {:main-opts ["-m" "fc4c.cli"]}}}

--- a/src/fc4c/cli.clj
+++ b/src/fc4c/cli.clj
@@ -1,0 +1,12 @@
+(ns fc4c.cli
+  (:require [fc4c.clipboard :refer [wcb]]
+            [clojure.core.async :as ca :refer [<!!]]))
+
+(defn -main []
+  (let [c (wcb)]
+    (println "Now watching clipboard for FC4 diagrams in YAML format. Hit ctrl-c to exit.")
+    
+    ;; Block until wcb’s return channel emits something. Which it won’t, so
+    ;; effectively block forever, or until the user hits ctrl-c, whichever
+    ;; happens first.
+    (<!! c)))

--- a/src/fc4c/core.clj
+++ b/src/fc4c/core.clj
@@ -6,7 +6,7 @@
             [clojure.spec.alpha :as s]
             [com.gfredericks.test.chuck.generators :as gen']
             [flatland.ordered.map :refer [ordered-map]]
-            [clojure.string :as str :refer [blank? join split trim]]
+            [clojure.string :as str :refer [blank? includes? join split trim]]
             [clojure.walk :as walk :refer [postwalk]]
             [clojure.set :refer [difference intersection]]))
 
@@ -259,6 +259,11 @@
        %)
     d))
 
+(defn probably-diagram-yaml? [v]
+  (and (string? v)
+       (includes? v "type")
+       (includes? v "scope")))
+
 (defn fixup-yaml
   "Accepts a diagram as a YAML string and applies some custom formatting rules."
   [s]
@@ -299,11 +304,3 @@
                         "\n---\n"
                         (stringify main-processed))]
     [main-processed str-output]))
-
-(defn -main []
-  (-> (slurp *in*)
-      process-file
-      second
-      print)
-  (flush)
-  (Thread/sleep 10))

--- a/src/fc4c/repl.clj
+++ b/src/fc4c/repl.clj
@@ -1,85 +1,14 @@
 (ns fc4c.repl
-  "Some useful funcs for using Minimayaml from the REPL."
+  "Import some useful funcs for using FC4C from the REPL into this single
+  namespace, for convenience."
   (:require [clojure.repl :as cr]
-            [clojure.core.async :as ca :refer [<! chan go-loop offer! poll! timeout]]
-            [clojure.string :as str :refer [includes?]]
-            [fc4c.core :as rc]
             [fc4c.clipboard :as cb]
             [fc4c.files :as rf]
             [potemkin :refer [import-vars]]))
 
-(def stop-chan (chan 1))
-
-(defn probably-diagram-yaml? [v]
-  (and (string? v)
-       (includes? v "type")
-       (includes? v "scope")))
-
-(defn pcb
-  "Process Clipboard — process the contents of the clipboard and write the results back to the
-  clipboard. If the contents of the clipboard are not a FC4 diagram, a RuntimeException is
-  thrown."
-  []
-  (let [contents (cb/slurp)]
-    (if (probably-diagram-yaml? contents)
-      (-> contents
-          rc/process-file
-          second
-          cb/spit)
-      (throw (RuntimeException. "Not a FC4 diagram.")))))
-
-(def current-local-time-format
-  (java.text.SimpleDateFormat. "HH:mm:ss"))
-
-(defn current-local-time-str []
-  (.format current-local-time-format (java.util.Date.)))
-
-(defn try-process [contents]
-  (try
-     (let [[main str-result] (rc/process-file contents)
-           _ (cb/spit str-result)
-           {:keys [:type :scope]} main]
-       (println (current-local-time-str) "-> processed" type "for" scope "with great success!")
-       (flush)
-       str-result)
-     (catch Exception err
-       ; toString _should_ suffice but some of the SnakeYAML exception classes seem to have a bug in
-       ; their toString implementations wherein they don’t print their names.
-       (println (-> err class .getSimpleName) "->" (.getMessage err))
-       (flush)
-       nil)))
-
-(defn wcb
-  "Start a background routine that watches the clipboard for changes. If the
-  changed content is a FC4 diagram in YAML, processes it and writes the
-  result back to the clipboard.
-  
-  Stop the routine by calling stop."
-  []
-  ;; Just in case stop was accidentally called twice, in which case there’d be a superfluous value
-  ;; in the channel, we’ll remove a value from the channel just before we get started.
-  (poll! stop-chan)
-
-  (go-loop [prior-contents nil]
-    (let [contents (cb/slurp)
-          process? (and (not= contents prior-contents)
-                        (probably-diagram-yaml? contents))
-          output (when process?
-                   (try-process contents))]          
-      (if (poll! stop-chan)
-        (do (println "Stopped!") (flush))
-        (let [contents (cb/slurp)]
-          (<! (timeout 1000))
-          (recur contents)))))
-  nil)
-
-(defn stop
-  "Stop the goroutine started by wcb."
-  []
-  (offer! stop-chan true))
-
 ;; Make process-dir readily accessible
-(import-vars [fc4c.files process-dir])
+(import-vars [fc4c.clipboard pcb wcb stop]
+             [fc4c.files process-dir])
 
 ;; Print docs for the most handy-dandy funcs
 (doseq [s ['pcb 'wcb 'stop 'process-dir]]

--- a/wcb
+++ b/wcb
@@ -1,0 +1,2 @@
+# wcb = “watch clipboard”
+clj -M:wcb

--- a/wcb
+++ b/wcb
@@ -1,3 +1,3 @@
 #!/bin/sh
 # wcb = “watch clipboard”
-clj -M:wcb
+clojure -M:wcb

--- a/wcb
+++ b/wcb
@@ -1,2 +1,3 @@
+#!/bin/sh
 # wcb = “watch clipboard”
 clj -M:wcb


### PR DESCRIPTION
Simplifies the UX for the most common usage case.

Also moved a bunch of fns from `.repl` to `.clipboard` because it makes more sense now that they’re used by `.cli`.

Refs [ENG-1478](https://jira.fundingcircle.com/browse/ENG-1478)