### PR TITLE
CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
    build:
      docker:
-       - image: circleci/clojure:tools-deps
+       - image: clojure:tools-deps-alpine
      steps:
        - checkout
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,11 @@ jobs:
        - run: "clojure -R:run-tests -e '(println \"deps are installed!\")'"
 
        # Run the tests
-       - run: "clojure -A:run-tests"
+       # The max heap size is set to 1GB because CI machines/containers frequently have <=4GB of
+       # RAM, and JDK 8 defaults to setting the max heap to 1/4 of the total RAM, but such a small
+       # heap max leads to OOM errors when running the tests (at 512MB; I’ve only tested 512MB and
+       # 1GB).
+       - run: "clojure -J-Xmx1g -A:run-tests"
 
        # Save the dependencies cache
        - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,10 @@ jobs:
            - dependencies-
 
        # Download deps if necessary. (clj automatically downloads deps if necessary)
-       - run: clj -e '(println "deps are installed!")'
+       - run: clojure -e '(println "deps are installed!")'
 
        # Run the tests
-       - run: "clj -A:run-tests"
+       - run: "clojure -A:run-tests"
 
        # Save the dependencies cache
        - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,11 +17,10 @@ jobs:
        - run: "clojure -R:run-tests -e '(println \"deps are installed!\")'"
 
        # Run the tests
-       # The max heap size is set to 1GB because CI machines/containers frequently have <=4GB of
-       # RAM, and JDK 8 defaults to setting the max heap to 1/4 of the total RAM, but such a small
-       # heap max leads to OOM errors when running the tests (at 512MB; I’ve only tested 512MB and
-       # 1GB).
-       - run: "clojure -J-Xmx1g -A:run-tests"
+       # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
+       # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
+       # <= 4GB RAM.)
+       - run: "clojure -J-Xmx2g -A:run-tests"
 
        # Save the dependencies cache
        - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,27 @@
+version: 2
+jobs:
+   build:
+     docker:
+       - image: circleci/clojure:tools-deps
+     steps:
+       - checkout
+
+       # Restore the dependencies cache, if it exists
+       - restore_cache:
+           keys:
+           - dependencies-{{ checksum "deps.edn" }}
+           # fallback to using the latest cache if no exact match is found
+           - dependencies-
+
+       # Download deps if necessary. (clj automatically downloads deps if necessary)
+       - run: clj -e '(println "deps are installed!")'
+
+       # Run the tests
+       - run: "clj -A:run-tests"
+
+       # Save the dependencies cache
+       - save_cache:
+           key: dependencies-{{ checksum "deps.edn" }}
+           paths:
+           - ~/.m2
+           - ~/.gitlibs

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
            - dependencies-
 
        # Download deps if necessary. (clj automatically downloads deps if necessary)
-       - run: "clojure -R:dev -e '(println \"deps are installed!\")'"
+       - run: "clojure -R:run-tests -e '(println \"deps are installed!\")'"
 
        # Run the tests
        - run: "clojure -A:run-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
            # fallback to using the latest cache if no exact match is found
            - dependencies-
 
-       # Download deps if necessary. (clj automatically downloads deps if necessary)
+       # Download deps if necessary. (clojure automatically downloads deps if necessary)
        - run: "clojure -R:run-tests -e '(println \"deps are installed!\")'"
 
        # Run the tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
            - dependencies-
 
        # Download deps if necessary. (clj automatically downloads deps if necessary)
-       - run: clojure -e '(println "deps are installed!")'
+       - run: "clojure -R:dev -e '(println \"deps are installed!\")'"
 
        # Run the tests
        - run: "clojure -A:run-tests"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,15 +16,15 @@ jobs:
        # Download deps if necessary. (clojure automatically downloads deps if necessary)
        - run: "clojure -R:run-tests -e '(println \"deps are installed!\")'"
 
-       # Run the tests
-       # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
-       # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
-       # <= 4GB RAM.)
-       - run: "clojure -J-Xmx2g -A:run-tests"
-
        # Save the dependencies cache
        - save_cache:
            key: dependencies-{{ checksum "deps.edn" }}
            paths:
            - ~/.m2
            - ~/.gitlibs
+
+       # Run the tests
+       # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
+       # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
+       # <= 4GB RAM.)
+       - run: "clojure -J-Xmx2g -A:run-tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN clojure -Rrun-tests -e '(println "Our deps are in the house!")'
 # Now copy all the app code.
 COPY . ./
 
-# The max heap size is set to 1GB because Docker machines frequently have less than 4GB of RAM, and
-# JDK 8 defaults to setting the max heap to 1/4 of the total RAM, but such a small heap max leads
-# to OOM errors when running the tests (at 512MB; I’ve only tested 512MB and 1GB).
-ENTRYPOINT clojure -J-Xmx1g -A:run-tests
+# The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8 defaults to
+# setting the max heap to ¼ of the total RAM, and containers frequently have <= 4GB RAM.)
+ENTRYPOINT clojure -J-Xmx2g -A:run-tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,12 @@
-FROM openjdk:8-alpine
+FROM clojure:tools-deps-alpine
 
 LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
-WORKDIR /tmp
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --update --no-cache bash curl
-RUN curl -O https://download.clojure.org/install/linux-install-1.9.0.326.sh
-RUN chmod +x linux-install-1.9.0.326.sh
-RUN ./linux-install-1.9.0.326.sh
-
-# Use the `clojure` script to evaluate a simple form so as to to download Clojure itself so we
-# don’t have to re-download it and make a new image whenever the deps or the app code change.
-RUN clojure -e '(println "Clojure is in the house!")'
-
 WORKDIR /code
 
-# Copy deps.edn, then trigger clj to download the deps, separately from and prior to copying the
-# app code so that we don’t have to re-download deps every time the app code changes.
+# Copy deps.edn then invoke `clojure` with a simple form just to download the deps, separately
+# from and prior to copying the app code so that we don’t have to re-download deps every time the
+# app code changes.
 COPY deps.edn ./
 RUN clojure -Rrun-tests -e '(println "Our deps are in the house!")'
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,27 +4,26 @@ LABEL maintainer="Avi Flax <avi.flax@fundingcircle.com>"
 
 WORKDIR /tmp
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN apk add --update --no-cache bash curl rlwrap@testing
+RUN apk add --update --no-cache bash curl
 RUN curl -O https://download.clojure.org/install/linux-install-1.9.0.326.sh
 RUN chmod +x linux-install-1.9.0.326.sh
 RUN ./linux-install-1.9.0.326.sh
 
-# Trigger clj to download Clojure itself so we don’t have to re-download it and make a new image
-# whenever the deps or the app code change.
-RUN echo '(println "Clojure is in the house!")' | clj
+# Use the `clojure` script to evaluate a simple form so as to to download Clojure itself so we
+# don’t have to re-download it and make a new image whenever the deps or the app code change.
+RUN clojure -e '(println "Clojure is in the house!")'
 
 WORKDIR /code
 
 # Copy deps.edn, then trigger clj to download the deps, separately from and prior to copying the
 # app code so that we don’t have to re-download deps every time the app code changes.
 COPY deps.edn ./
-RUN echo '(println "Our deps are in the house!")' | clj -Ctest -Rtest -
+RUN clojure -Rrun-tests -e '(println "Our deps are in the house!")'
 
 # Now copy all the app code.
 COPY . ./
 
-# The sleep is a workaround found here: https://github.com/sflyr/docker-sqlplus/pull/2
 # The max heap size is set to 1GB because Docker machines frequently have less than 4GB of RAM, and
 # JDK 8 defaults to setting the max heap to 1/4 of the total RAM, but such a small heap max leads
 # to OOM errors when running the tests (at 512MB; I’ve only tested 512MB and 1GB).
-ENTRYPOINT sleep 1; clj -J-Xmx1g -A:run-tests
+ENTRYPOINT clojure -J-Xmx1g -A:run-tests

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As explained in
 1. Install Clojure as per [this guide](https://clojure.org/guides/getting_started)
 2. Clone this repo
 3. `cd` into the repo
-4. To install the dependencies, run: `clj -e '(println "deps installed!")'`
+4. To install the dependencies, run: `clojure -e '(println "deps installed!")'`
 
 ## Basic Usage
 
@@ -74,7 +74,7 @@ docker run --rm `docker build -q .`
 If you’re old-school and prefer to run tests on bare metal:
 
 1. Have `clj` installed ([guide](https://clojure.org/guides/getting_started))
-1. Run in your shell: `clj -A:run-tests`
+1. Run in your shell: `clojure -A:run-tests`
 
 ## Starting a REPL for Dev/Test
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As explained in
 1. Install Clojure as per [this guide](https://clojure.org/guides/getting_started)
 2. Clone this repo
 3. `cd` into the repo
-4. To install the dependencies, run: `clojure -e '(println "deps installed!")'`
+4. To install the dependencies, run: `clojure -R:dev -e '(println "deps installed!")'`
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A tool for reorganizing, restructuring, and reformatting
 [FC4](https://fundingcircle.github.io/fc4-framework/) diagrams.
 
+[![CircleCI](https://circleci.com/gh/FundingCircle/fc4c.svg?style=shield)](https://circleci.com/gh/FundingCircle/fc4c)
 
 ## Purpose
 

--- a/deps.edn
+++ b/deps.edn
@@ -20,5 +20,5 @@
                                      ;; This fork returns a non-zero status when tests fail; crucial when building in a CI server.
                                      ;; See https://github.com/cognitect-labs/test-runner/pull/12
                                      com.cognitect/test-runner  {:git/url "https://github.com/Olical/test-runner"
-                                                                 :sha "427a16c634201492984d2161d305baa09ab864cd"}}
+                                                                 :sha "7c4f5bd4987ec514889c7cd7e3d13f4ef95f256b"}}
                        :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -17,6 +17,8 @@
                                                                  :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}}
            :run-tests {:extra-paths ["test"]
                        :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     com.cognitect/test-runner  {:git/url "https://github.com/cognitect-labs/test-runner"
-                                                                 :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}
+                                     ;; This fork returns a non-zero status when tests fail; crucial when building in a CI server.
+                                     ;; See https://github.com/cognitect-labs/test-runner/pull/12
+                                     com.cognitect/test-runner  {:git/url "https://github.com/Olical/test-runner"
+                                                                 :sha "427a16c634201492984d2161d305baa09ab864cd"}}
                        :main-opts   ["-m" "cognitect.test-runner"]}}}

--- a/test/fc4c/core_test.clj
+++ b/test/fc4c/core_test.clj
@@ -3,9 +3,6 @@
             [clojure.test :refer [deftest]]
             [fc4c.test-utils :refer [check]]))
 
-;; temporarily break the tests to ensure that CI builds will fail when the tests fail
-(deftest whatever (clojure.test/is (= 1 2)))
-
 (deftest blank-nil-or-empty? (check `rc/blank-nil-or-empty?))
 (deftest parse-coords (check `rc/parse-coords))
 (deftest round-to-closest (check `rc/round-to-closest))

--- a/test/fc4c/core_test.clj
+++ b/test/fc4c/core_test.clj
@@ -3,6 +3,9 @@
             [clojure.test :refer [deftest]]
             [fc4c.test-utils :refer [check]]))
 
+;; temporarily break the tests to ensure that CI builds will fail when the tests fail
+(deftest whatever (clojure.test/is (= 1 2)))
+
 (deftest blank-nil-or-empty? (check `rc/blank-nil-or-empty?))
 (deftest parse-coords (check `rc/parse-coords))
 (deftest round-to-closest (check `rc/round-to-closest))


### PR DESCRIPTION
This adds a CircleCI build config, and also:

* Switches the commands in the README and in the Dockerfile to use the `clojure` script rather than `clj`
  * As per [the tools.deps reference](https://clojure.org/reference/deps_and_cli#_usage), the `clojure` script is a runner for Clojure while `clj` is a wrapper for interactive repl use. 
* Bumps the max heap size to 2GB when running the tests from the Dockerfile
  * I saw a few OOM errors when testing with the max at 1GB
* Since I was already in the Dockerfile, I streamlined it by switching to a new base image that’s now available that already has Clojure and tools.deps installed.

[ENG-1481](https://jira.fundingcircle.com/browse/ENG-1481)