### PR TITLE
New data structure/format representing a unified model of all systems and users

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ If you’re old-school and prefer to run tests on bare metal:
 You could just run `clj` but you’re likely to want the test deps and code to be accessible. In that
 case run `clj -Adev`
 
+## Running the Linter
+
+For linting, this project uses [cljfmt](https://github.com/weavejester/cljfmt),
+via [cljfmt-runner](https://github.com/JamesLaverack/cljfmt-runner).
+
+* To lint the entire project, run `clojure -A:lint`
+* To lint the entire project **and automatically fix any problems found** run
+  `clojure -A:lint:lint/fix`
+  * This will change the files on disk but will not commit the changes nor stage
+    them into the git index. This way you can review the changes that were
+    applied and decide which to keep and which to discard.
+
+We’ll soon be integrating a lint run into our CI builds so they’ll fail if any
+source code is formatted incorrectly. Coming soon!
+
 ## Contributors
 
 * @99-not-out

--- a/deps.edn
+++ b/deps.edn
@@ -2,29 +2,37 @@
  {org.clojure/core.async {:mvn/version "0.4.474"}
   circleci/clj-yaml {:mvn/version "0.5.6"}
   potemkin {:mvn/version "0.4.4"}
+  expound {:mvn/version "0.7.0"}
+  com.cognitect/anomalies {:mvn/version "0.1.12"}
 
-  ;; test.chuck is in the main dependency list, rather than in the test profile, because we’re
-  ;; using one of its generators in a spec in a source file.
+  ;; Normally test.check would only be present in profiles like :dev, :test,
+  ;; etc. That way it wouldn’t need to be included in distributed/built
+  ;; artifacts nor downloaded/used at runtime. Unfortunately we have a few
+  ;; generators that need to use let, which for some reason isn’t included in
+  ;; clojure.spec.gen.alpha. We might be able to make our own lazy-loading alias
+  ;; for let. So TBD I guess.
+  org.clojure/test.check {:mvn/version "0.9.0"}
+
+  ;; test.chuck is in the main dependency list, rather than in the test profile,
+  ;; because we’re using one of its generators in a spec in a source file.
   com.gfredericks/test.chuck {:mvn/version "0.2.8"}}
 
  :aliases {:dev       {:extra-paths ["test"]
-                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
+                       :extra-deps  {org.clojure/tools.trace    {:mvn/version "0.7.9"}
+                                     inspectable                {:mvn/version "0.2.2"}
                                      com.cognitect/test-runner  {:git/url "https://github.com/cognitect-labs/test-runner"
                                                                  :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}}
            :test      {:extra-paths ["test"]
-                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     com.cognitect/test-runner  {:git/url "https://github.com/cognitect-labs/test-runner"
+                       :extra-deps  {com.cognitect/test-runner  {:git/url "https://github.com/cognitect-labs/test-runner"
                                                                  :sha "76568540e7f40268ad2b646110f237a60295fa3c"}}}
            :run-tests {:extra-paths ["test"]
-                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     ;; This fork returns a non-zero status when tests fail; crucial when building in a CI server.
+                       :extra-deps  {;; This fork returns a non-zero status when tests fail; crucial when building in a CI server.
                                      ;; See https://github.com/cognitect-labs/test-runner/pull/12
                                      com.cognitect/test-runner  {:git/url "https://github.com/Olical/test-runner"
                                                                  :sha "7c4f5bd4987ec514889c7cd7e3d13f4ef95f256b"}}
                        :main-opts   ["-m" "cognitect.test-runner"]}
            :coverage {:extra-paths  ["test"]
-                      :extra-deps   {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     cloverage                  {:mvn/version "1.0.10"}}
+                      :extra-deps   {cloverage                  {:mvn/version "1.0.10"}}
                       :main-opts    ["-m" "cloverage.coverage"
                                      ;; TODO: make this regex exclude fc4c.test-utils
                                      "--ns-regex" "^fc4c.+(?<!test)"

--- a/deps.edn
+++ b/deps.edn
@@ -31,13 +31,18 @@
                                      com.cognitect/test-runner  {:git/url "https://github.com/Olical/test-runner"
                                                                  :sha "7c4f5bd4987ec514889c7cd7e3d13f4ef95f256b"}}
                        :main-opts   ["-m" "cognitect.test-runner"]}
-           :coverage {:extra-paths  ["test"]
-                      :extra-deps   {cloverage                  {:mvn/version "1.0.10"}}
-                      :main-opts    ["-m" "cloverage.coverage"
-                                     ;; TODO: make this regex exclude fc4c.test-utils
-                                     "--ns-regex" "^fc4c.+(?<!test)"
-                                     "--test-ns-regex" "fc4c.+\\-test$"
-                                     "--fail-threshold" "65"
-                                     "--codecov"]}
+           :coverage  {:extra-paths  ["test"]
+                       :extra-deps   {cloverage                  {:mvn/version "1.0.10"}}
+                       :main-opts    ["-m" "cloverage.coverage"
+                                      ;; TODO: make this regex exclude fc4c.test-utils
+                                      "--ns-regex" "^fc4c.+(?<!test)"
+                                      "--test-ns-regex" "fc4c.+\\-test$"
+                                      "--fail-threshold" "65"
+                                      "--codecov"]}
+           :lint      {:extra-deps {com.jameslaverack/cljfmt-runner
+                                    {:git/url "https://github.com/JamesLaverack/cljfmt-runner"
+                                     :sha "51f85c9d6cc67107620749ceacd46120647fe107"}}
+                       :main-opts ["-m" "cljfmt-runner.check"]}
+           :lint/fix  {:main-opts ["-m" "cljfmt-runner.fix"]}
            :wcb ;; wcb = “watch clipboard”
            {:main-opts ["-m" "fc4c.cli"]}}}

--- a/src/fc4c/files.clj
+++ b/src/fc4c/files.clj
@@ -20,8 +20,8 @@
         (map str [path parent-path])] ; coerce to strings in case they’re Files
     (when (starts-with? p pp)
       (subs p (if (ends-with? pp "/")
-                  (count pp)
-                  (inc (count pp)))))))
+                (count pp)
+                (inc (count pp)))))))
 
 (defn process-dir
   "Accepts a directory path as a string, finds all the YAML files in that dir or

--- a/src/fc4c/files.clj
+++ b/src/fc4c/files.clj
@@ -1,6 +1,6 @@
 (ns fc4c.files
   (:require [clojure.java.io :as io]
-            [clojure.string :as str :refer [ends-with?]]))
+            [clojure.string :as str :refer [ends-with? starts-with?]]))
 
 (defn yaml-files
   "Accepts a directory as a path string or a java.io.File, returns a lazy sequence of java.io.File objects for
@@ -11,12 +11,17 @@
        (filter #(or (ends-with? % ".yaml")
                     (ends-with? % ".yml")))))
 
-(defn relativize [path parent-path]
-  (let [p  (str path) ; coerce to string as it might be a File
-        pp (str parent-path)]
-    (subs p (if (ends-with? pp "/")
-                (count pp)
-                (inc (count pp))))))
+(defn relativize
+  "Accepts two absolute paths. If the first is a “child” of the second, the
+  first is relativized to the second and returned as a string. If it is not,
+  returns nil."
+  [path parent-path]
+  (let [[p pp]
+        (map str [path parent-path])] ; coerce to strings in case they’re Files
+    (when (starts-with? p pp)
+      (subs p (if (ends-with? pp "/")
+                  (count pp)
+                  (inc (count pp)))))))
 
 (defn process-dir
   "Accepts a directory path as a string, finds all the YAML files in that dir or

--- a/src/fc4c/files.clj
+++ b/src/fc4c/files.clj
@@ -31,7 +31,8 @@
   immediately, aborting the work."
   [dir-path f]
   (doseq [file (yaml-files dir-path)]
-    (println (relativize (str file) dir-path))
+    (binding [*out* *err*]
+      (println (relativize (str file) dir-path)))
     (->> (slurp file)
          (f)
          (spit file))))

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -1,0 +1,225 @@
+(ns fc4c.model
+  (:refer-clojure :exclude [read])
+  (:require [clj-yaml.core :as yaml]
+            [clojure.java.io :as io]
+            [clojure.set :refer [union]]
+            [clojure.spec.alpha :as s]
+            [clojure.string :refer [blank? ends-with? includes? join split]]
+            ;; Can’t use clojure.spec.gen because it doesn’t include let
+            [clojure.test.check.generators :as gen]
+            [clojure.walk :refer [postwalk]]
+            [cognitect.anomalies :as anom]
+            [expound.alpha :as expound :refer [expound-str]]
+            [fc4c.files :refer [yaml-files relativize]]))
+
+;; Fairly generic stuff:
+(s/def ::non-empty-string (s/and string? (complement blank?)))
+(s/def ::no-linebreaks  (s/and string? #(not (includes? % "\n"))))
+(s/def ::non-empty-simple-string (s/and ::non-empty-string ::no-linebreaks))
+
+;; Less generic stuff:
+(s/def ::name
+  (s/with-gen ::non-empty-simple-string
+    ;; This needs to generate a small and stable set of names so that the
+    ;; generated relationships have a chance of being valid — or at least useful.
+    #(gen/elements ["Front" "Middle" "Back" "Internal" "External" "Mobile"])))
+
+(s/def ::description ::non-empty-string)
+
+;; Non-generic stuff:
+
+;;; Should really be a set, I guess, but that would be annoying to do yet
+;;; post-processing walk. Perhaps instead of using YAML we should just use EDN
+;;; files?
+(s/def ::repos (s/coll-of ::non-empty-simple-string))
+
+(s/def ::tags
+  (s/coll-of (s/and keyword?
+                    (comp (partial s/valid? ::non-empty-simple-string) name))
+             :kind set?))
+
+(s/def ::system ::name)
+(s/def ::container ::name)
+(s/def ::technology ::non-empty-simple-string)
+
+(s/def ::system-ref
+  (s/keys
+    ;; Must contain *either* ::system *or* ::container, or both, so as to
+    ;; support these cases:
+    ;;
+    ;; * a system or container might use a different system with or without
+    ;;   specifying the container
+    ;; * a container might use a different container of the same/current system,
+    ;;   in which case the system is implicit
+    ;;
+    ;; FYI, the generator doesn’t currently respect the `or` below; a fix for
+    ;; this has been contributed to core.spec but not yet released:
+    ;; https://dev.clojure.org/jira/browse/CLJ-2046
+    :req [(or ::container ::system (and ::system ::container))]
+    :opt [::technology ::description]))
+
+;;; order doesn’t really matter here, so I guess it should be a set?
+(s/def ::uses
+  (s/with-gen (s/coll-of ::system-ref :min-count 1)
+    #(gen/vector (s/gen ::system-ref) 5 10)))
+
+(s/def ::container-map
+  (s/keys
+    :req [::name]
+    :opt [::description ::technology ::uses]))
+
+;;; Order doesn’t really matter here, so I guess it should be a set? Or maybe a
+;;; map of container names to container-maps? That would be consistent with
+;;; ::systems.
+(s/def ::containers (s/coll-of ::container-map))
+
+(s/def ::element
+  (s/keys
+    :req [::name]
+    :opt [::description ::uses]))
+
+(s/def ::system-map
+  (s/merge ::element
+           (s/keys :opt [::containers ::repos ::tags])))
+
+(s/def ::systems
+  (s/with-gen (s/map-of ::name ::system-map :min-count 1)
+    #(gen/let [m (s/gen (s/coll-of ::system-map))]
+       (->> m
+            (mapcat (juxt ::name identity))
+            (apply hash-map)))))
+
+(s/def ::user-map (s/merge ::element (s/keys :req [::uses])))
+
+(s/def ::users
+  (s/with-gen (s/map-of ::name ::user-map :min-count 1)
+    #(gen/let [m (s/gen (s/coll-of ::user-map))]
+       (->> m
+            (mapcat (juxt ::name identity))
+            (apply hash-map)))))
+
+(s/def ::model (s/keys :req [::systems ::users]))
+
+(defn- get-tags-from-path [file relative-root]
+  (as-> (relativize file relative-root) v
+        (split v #"/")
+        (map keyword v)
+        (drop-last v)
+        (set v)
+        (conj v (if (includes? (.getName file) "external")
+                    :external
+                    :in-house))))
+
+(defn- add-ns [namespace keeword]
+  (keyword (name namespace) (name keeword)))
+
+(s/def ::keyword-or-simple-string
+  (s/or :keyword keyword?
+        :string  ::non-empty-simple-string))
+
+(s/fdef add-ns
+  :args (s/cat :namespace ::keyword-or-simple-string
+               :keyword   ::keyword-or-simple-string)
+  :ret  qualified-keyword?)
+
+; We have to capture this at compile time in order for it to have the value we
+; want it to; if we referred to *ns* in the body of a function then, because it
+; is dynamically bound, it would return the namespace at the top of the stack,
+; the “currently active namespace” rather than what we want, which is the
+; namespace of this file, because that’s the namespace all our keywords are
+; qualified with.
+(def ^:private this-ns-name (str *ns*))
+
+(defn- qualify-keys
+  "Given a nested map with keyword keys, qualifies all keys, recursively, with
+  the current namespace."
+  {:fork-of 'clojure.walk/stringify-keys}
+  [m]
+  (let [f (fn [[k v]]
+            (if (and (keyword? k)
+                     (not (qualified-keyword? k)))
+                [(add-ns this-ns-name k) v]
+                [k v]))]
+    ;; only apply to maps
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
+
+(s/fdef qualify-keys
+  :args (s/cat :map (s/map-of keyword? any?))
+  :ret  (s/map-of qualified-keyword? any?))
+
+;; This is starting to feel silly… I mean, really ::repos should be a set too.
+;; Perhaps instead of using YAML we should just use EDN files?
+(defn- fixup-tags
+  "Given a nested map, finds all entries with the key being ::tags and ensures
+  that the value is a set of keywords."
+  {:fork-of 'clojure.walk/stringify-keys}
+  [m]
+  (let [this-ns (str *ns*)
+        f (fn [[k v]]
+            (if (= k ::tags)
+                [k (->> v (map keyword) set)]
+                [k v]))]
+    ;; only apply to maps
+    (postwalk (fn [x] (if (map? x) (into {} (map f x)) x)) m)))
+
+(defn- add-tags
+  [tags-from-path elem]
+  (update elem ::tags (fn [ov] (if ov
+                                 (union ov tags-from-path)
+                                 tags-from-path))))
+
+(s/fdef add-tags
+  :args (s/cat :tags ::tags
+               :elem ::element)
+  :ret  (s/merge ::element (s/keys :req [::tags])))
+
+;;;; TODO: the functions below don’t sufficiently separate I/O from computation.
+
+;; TODO: validate the contents of the file? Or maybe have that be a separate
+;;       function?
+;; A file might contain a single system as a map, or a sequential containing
+;; multiple systems.
+(defn elements-from-file [file relative-root]
+  (let [parsed (-> file
+                   slurp
+                   yaml/parse-string)
+        elems (if (associative? parsed)
+                  [parsed]
+                  parsed)
+        tags-from-path (get-tags-from-path file relative-root)]
+    (map (comp (partial add-tags tags-from-path)
+               fixup-tags
+               qualify-keys)
+         elems)))
+
+(defn read-elements [root-path]
+  (->> (yaml-files root-path)
+       (mapcat #(elements-from-file % root-path))
+       (mapcat (juxt ::name identity))
+       (apply hash-map)))
+
+(defn read
+  "Pass the path of a dir (must have trailing slash) that contains the dirs
+  \"systems\" and \"users\"."
+  [root-path]
+  (let [model {::systems (read-elements (io/file root-path "systems"))
+               ::users (read-elements (io/file root-path "users"))}]
+    (if (s/valid? ::model model)
+        model
+        {::anom/category ::anom/fault
+         ::anom/message (expound-str ::model model)
+         ::model model})))
+
+(s/def ::dir-path
+  (s/with-gen (s/and ::non-empty-simple-string
+                     #(ends-with? % "/"))
+              #(gen/let [s (s/gen ::non-empty-simple-string)]
+                 (str (->> (repeat 5 s) (join "/")) "/"))))
+
+;; Not useful for generative testing because the function does I/O; see comment
+;; in model_test.clj.
+(s/fdef read
+  :args (s/cat :dir-path ::dir-path)
+  :ret  (s/or :success ::model
+              :error   (s/merge ::anom/anomaly
+                                (s/keys :req [::model]))))

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -32,7 +32,8 @@
 
 ;; Less generic stuff:
 (s/def ::name
-  (s/with-gen ::short-non-blank-simple-str
+  (s/with-gen
+    ::short-non-blank-simple-str
     ;; This needs to generate a small and stable set of names so that the
     ;; generated relationships have a chance of being valid — or at least useful.
     #(gen/elements ["Front" "Middle" "Back" "Internal" "External" "Mobile"])))
@@ -78,7 +79,8 @@
 
 ;;; order doesn’t really matter here, so I guess it should be a set?
 (s/def ::uses
-  (s/with-gen (s/coll-of ::system-ref :min-count 1)
+  (s/with-gen
+    (s/coll-of ::system-ref :min-count 1)
     #(gen/vector (s/gen ::system-ref) 5 10)))
 
 (s/def ::container-map
@@ -89,7 +91,8 @@
 ;;; Order doesn’t really matter here, so I guess it should be a set? Or maybe a
 ;;; map of container names to container-maps? That would be consistent with
 ;;; ::systems.
-(s/def ::containers (s/coll-of ::container-map))
+(s/def ::containers
+  (s/coll-of ::container-map))
 
 (s/def ::element
   (s/keys
@@ -101,7 +104,8 @@
            (s/keys :opt [::containers ::repos])))
 
 (s/def ::systems
-  (s/with-gen (s/map-of ::name ::system-map :min-count 1)
+  (s/with-gen
+    (s/map-of ::name ::system-map :min-count 1)
     #(gen/let [m (s/gen (s/coll-of ::system-map))]
        (->> m
             (mapcat (juxt ::name identity))
@@ -112,23 +116,27 @@
            (s/keys :req [::uses])))
 
 (s/def ::users
-  (s/with-gen (s/map-of ::name ::user-map :min-count 1)
+  (s/with-gen
+    (s/map-of ::name ::user-map :min-count 1)
     #(gen/let [m (s/gen (s/coll-of ::user-map))]
        (->> m
             (mapcat (juxt ::name identity))
             (apply hash-map)))))
 
-(s/def ::model (s/keys :req [::systems ::users]))
+(s/def ::model
+  (s/keys :req [::systems ::users]))
 
 (s/def ::dir-path
-  (s/with-gen (s/and ::non-blank-simple-str
-                     #(ends-with? % "/"))
+  (s/with-gen
+    (s/and ::non-blank-simple-str #(ends-with? % "/"))
     #(gen/let [s (s/gen ::short-non-blank-simple-str)]
        (str (->> (repeat 5 s) (join "/")) "/"))))
 
-(s/def ::file (partial instance? java.io.File))
+(s/def ::file
+  (partial instance? java.io.File))
 
-(s/def ::dir-path-or-file (s/or ::dir-path ::file))
+(s/def ::dir-path-or-file
+  (s/or ::dir-path ::file))
 
 (defn- get-tags-from-path
   [file relative-root]
@@ -146,7 +154,8 @@
                      :relative-root ::dir-path)
         :ret ::tags)
 
-(defn- add-ns [namespace keeword]
+(defn- add-ns
+  [namespace keeword]
   (keyword (name namespace) (name keeword)))
 
 (s/def ::keyword-or-simple-string
@@ -170,7 +179,8 @@
        x))
    m))
 
-(s/def ::map-entry (s/tuple any? any?))
+(s/def ::map-entry
+  (s/tuple any? any?))
 
 (s/fdef update-all
         :args (s/cat :fn (s/fspec :args (s/cat :entry ::map-entry)
@@ -220,9 +230,11 @@
       (update ::tags to-set-of-keywords)
       (update ::tags (partial union tags-from-path))))
 
-(s/def ::simple-strings (s/coll-of ::short-non-blank-simple-str))
-(s/def ::unqualified-keyword (s/and keyword?
-                                    (complement qualified-keyword?)))
+(s/def ::simple-strings
+  (s/coll-of ::short-non-blank-simple-str))
+
+(s/def ::unqualified-keyword
+  (s/and keyword? (complement qualified-keyword?)))
 
 (s/def ::proto-element
   (s/with-gen
@@ -251,17 +263,20 @@
          elems)))
 
 (s/def ::element-yaml-string
-  (s/with-gen ::non-blank-str
+  (s/with-gen
+    ::non-blank-str
     #(gen/let [element (s/gen ::element)]
        (yaml/generate-string element))))
 
 (s/def ::elements-yaml-string
-  (s/with-gen ::non-blank-str
+  (s/with-gen
+    ::non-blank-str
     #(gen/let [elements (s/gen (s/coll-of ::element))]
        (yaml/generate-string elements))))
 
 (s/def ::yaml-file-contents
-  (s/with-gen ::non-blank-str
+  (s/with-gen
+    ::non-blank-str
     #(gen/one-of (map s/gen [::element-yaml-string ::elements-yaml-string]))))
 
 (s/fdef elements-from-file

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -5,7 +5,7 @@
             [clojure.set :refer [union]]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
-            [clojure.string :refer [blank? ends-with? includes? join split]]            
+            [clojure.string :refer [blank? ends-with? includes? join split]]
             [clojure.walk :refer [postwalk]]
             [cognitect.anomalies :as anom]
             [expound.alpha :as expound :refer [expound-str]]
@@ -151,13 +151,13 @@
   ancestor root directory (as a String or a java.io.File), extracts a set of
   tags from set of directories that are descendants of the ancestor root dir. If
   the file path includes “external” then the tag :external will be added to the
-  returned set; if not then the tag :in-house will be added. (TODO: change this to :internal)
+  returned set; if not then the tag :internal will be added.
 
   For example:
   => (get-tags-from-path
        \"/docs/fc4/model/systems/uk/compliance/panopticon.yaml\"
        \"/docs/fc4/model/systems/\")
-  #{:uk :compliance :in-house}"
+  #{:uk :compliance :internal}"
   [file relative-root]
   (as-> (or (relativize file relative-root) (str file)) v
     (split v #"/")
@@ -166,8 +166,11 @@
     (set v)
     (conj v (if (includes? (str file) "external")
               :external
-              :in-house))))
+              :internal))))
 
+;; TODO: for this spec to be truly useful in QA terms, it really needs an fspec
+;; and better generators (the generators will need to create two paths that are
+;; usefully and realistic related).
 (s/fdef get-tags-from-path
         :args (s/cat :file          ::dir-path-or-file
                      :relative-root ::dir-path-or-file)

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -201,6 +201,23 @@
       (update ::tags to-set-of-keywords)
       (update ::tags (partial union tags-from-path))))
 
+(s/def ::simple-strings (s/coll-of ::non-empty-simple-string))
+(s/def ::unqualified-keyword (s/and keyword?
+                                    (complement qualified-keyword?)))
+
+(s/def ::proto-element
+  (s/with-gen
+    (s/map-of ::unqualified-keyword (s/or :single-str ::non-empty-simple-string
+                                          :strings    ::simple-strings))
+    #(gen/hash-map :name  (s/gen ::name)
+                   :repos (s/gen ::simple-strings)
+                   :tags  (s/gen ::simple-strings))))
+
+(s/fdef fixup-element
+  :args (s/cat :tags-from-path ::tags
+               :proto-element  ::proto-element)
+  :ret ::element)
+
 ;; A file might contain a single element (as a map), or an array containing
 ;; multiple elements.
 (defn elements-from-file [file relative-root]

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -139,6 +139,17 @@
   (s/or ::dir-path ::file))
 
 (defn- get-tags-from-path
+  "Given a path to a file (as a String) and a path to an ancestor root directory
+  (as a String), extracts a set of tags from set of directories that are
+  descendants of the ancestor root dir. If the file path includes “external”
+  then the tag :external will be added to the returned set; if not then the tag
+  :in-house will be added. (TODO: change this to :internal)
+
+  For example:
+  => (get-tags-from-path
+       \"/docs/fc4/model/systems/uk/compliance/panopticon.yaml\"
+       \"/docs/fc4/model/systems/\")
+  #{:uk :compliance :in-house}"
   [file relative-root]
   (as-> (or (relativize file relative-root) file) v
     (split v #"/")

--- a/src/fc4c/model.clj
+++ b/src/fc4c/model.clj
@@ -50,9 +50,9 @@
 
 (s/def ::small-set-of-keywords
   (s/coll-of ::short-simple-keyword
-    :distinct true
-    :kind set?
-    :gen-max 10))
+             :distinct true
+             :kind set?
+             :gen-max 10))
 
 (s/def ::repos ::small-set-of-keywords)
 (s/def ::tags ::small-set-of-keywords)
@@ -73,8 +73,8 @@
     ;; FYI, the generator doesn’t currently respect the `or` below; a fix for
     ;; this has been contributed to core.spec but not yet released:
     ;; https://dev.clojure.org/jira/browse/CLJ-2046
-    :req [(or ::container ::system (and ::system ::container))]
-    :opt [::technology ::description]))
+   :req [(or ::container ::system (and ::system ::container))]
+   :opt [::technology ::description]))
 
 ;;; order doesn’t really matter here, so I guess it should be a set?
 (s/def ::uses
@@ -83,8 +83,8 @@
 
 (s/def ::container-map
   (s/keys
-    :req [::name]
-    :opt [::description ::technology ::uses]))
+   :req [::name]
+   :opt [::description ::technology ::uses]))
 
 ;;; Order doesn’t really matter here, so I guess it should be a set? Or maybe a
 ;;; map of container names to container-maps? That would be consistent with
@@ -93,8 +93,8 @@
 
 (s/def ::element
   (s/keys
-    :req [::name]
-    :opt [::description ::uses ::tags]))
+   :req [::name]
+   :opt [::description ::uses ::tags]))
 
 (s/def ::system-map
   (s/merge ::element
@@ -123,8 +123,8 @@
 (s/def ::dir-path
   (s/with-gen (s/and ::non-blank-simple-str
                      #(ends-with? % "/"))
-              #(gen/let [s (s/gen ::short-non-blank-simple-str)]
-                 (str (->> (repeat 5 s) (join "/")) "/"))))
+    #(gen/let [s (s/gen ::short-non-blank-simple-str)]
+       (str (->> (repeat 5 s) (join "/")) "/"))))
 
 (s/def ::file (partial instance? java.io.File))
 
@@ -133,18 +133,18 @@
 (defn- get-tags-from-path
   [file relative-root]
   (as-> (or (relativize file relative-root) file) v
-        (split v #"/")
-        (map keyword v)
-        (drop-last v)
-        (set v)
-        (conj v (if (includes? (str file) "external")
-                    :external
-                    :in-house))))
+    (split v #"/")
+    (map keyword v)
+    (drop-last v)
+    (set v)
+    (conj v (if (includes? (str file) "external")
+              :external
+              :in-house))))
 
 (s/fdef get-tags-from-path
-  :args (s/cat :file          ::dir-path
-               :relative-root ::dir-path)
-  :ret ::tags)
+        :args (s/cat :file          ::dir-path
+                     :relative-root ::dir-path)
+        :ret ::tags)
 
 (defn- add-ns [namespace keeword]
   (keyword (name namespace) (name keeword)))
@@ -154,9 +154,9 @@
         :string  ::non-blank-simple-str))
 
 (s/fdef add-ns
-  :args (s/cat :namespace ::keyword-or-simple-string
-               :keyword   ::keyword-or-simple-string)
-  :ret  qualified-keyword?)
+        :args (s/cat :namespace ::keyword-or-simple-string
+                     :keyword   ::keyword-or-simple-string)
+        :ret  qualified-keyword?)
 
 (defn- update-all
   "Given a map and a function of entry (coll of two elems) to entry, applies the
@@ -164,19 +164,19 @@
   {:fork-of 'clojure.walk/stringify-keys}
   [f m]
   (postwalk
-    (fn [x]
-      (if (map? x)
-        (into {} (map f x))
-        x))
-    m))
+   (fn [x]
+     (if (map? x)
+       (into {} (map f x))
+       x))
+   m))
 
 (s/def ::map-entry (s/tuple any? any?))
 
 (s/fdef update-all
-  :args (s/cat :fn (s/fspec :args (s/cat :entry ::map-entry)
-                            :ret  ::map-entry)
-               :map map?)
-  :ret map?)
+        :args (s/cat :fn (s/fspec :args (s/cat :entry ::map-entry)
+                                  :ret  ::map-entry)
+                     :map map?)
+        :ret map?)
 
 ; We have to capture this at compile time in order for it to have the value we
 ; want it to; if we referred to *ns* in the body of a function then, because it
@@ -191,26 +191,26 @@
   the current namespace."
   [m]
   (update-all
-    (fn [[k v]]
-      (if (and (keyword? k)
-               (not (qualified-keyword? k)))
-        [(add-ns this-ns-name k) v]
-        [k v]))
-    m))
+   (fn [[k v]]
+     (if (and (keyword? k)
+              (not (qualified-keyword? k)))
+       [(add-ns this-ns-name k) v]
+       [k v]))
+   m))
 
 (s/fdef qualify-keys
-  :args (s/cat :map (s/map-of keyword? any?))
-  :ret  (s/map-of qualified-keyword? any?))
+        :args (s/cat :map (s/map-of keyword? any?))
+        :ret  (s/map-of qualified-keyword? any?))
 
 (defn- to-set-of-keywords
   [xs]
   (-> (map keyword xs) set))
 
 (s/fdef to-set-of-keywords
-  :args (s/cat :xs (s/coll-of string?))
-  :ret  (s/coll-of keyword? :kind set?)
-  :fn (fn [{{:keys [xs]} :args, ret :ret}]
-        (= (count (distinct xs)) (count ret))))
+        :args (s/cat :xs (s/coll-of string?))
+        :ret  (s/coll-of keyword? :kind set?)
+        :fn (fn [{{:keys [xs]} :args, ret :ret}]
+              (= (count (distinct xs)) (count ret))))
 
 (defn- fixup-element
   [tags-from-path elem]
@@ -233,9 +233,9 @@
                    :tags  (s/gen ::simple-strings))))
 
 (s/fdef fixup-element
-  :args (s/cat :tags-from-path ::tags
-               :proto-element  ::proto-element)
-  :ret ::element)
+        :args (s/cat :tags-from-path ::tags
+                     :proto-element  ::proto-element)
+        :ret ::element)
 
 ;; A file might contain a single element (as a map), or an array containing
 ;; multiple elements.
@@ -258,17 +258,17 @@
 (s/def ::elements-yaml-string
   (s/with-gen ::non-blank-str
     #(gen/let [elements (s/gen (s/coll-of ::element))]
-      (yaml/generate-string elements))))
+       (yaml/generate-string elements))))
 
 (s/def ::yaml-file-contents
   (s/with-gen ::non-blank-str
     #(gen/one-of (map s/gen [::element-yaml-string ::elements-yaml-string]))))
 
 (s/fdef elements-from-file
-  :args (s/cat :file-contents ::yaml-file-contents
-               :file-path     ::dir-path
-               :root-path     ::dir-path)
-  :ret  (s/coll-of ::element))
+        :args (s/cat :file-contents ::yaml-file-contents
+                     :file-path     ::dir-path
+                     :root-path     ::dir-path)
+        :ret  (s/coll-of ::element))
 
 ;;;; The below functions do I/O. The function specs are provided as a form of
 ;;;; documentation and for instrumentation during development. They should not
@@ -286,8 +286,8 @@
        (apply hash-map)))
 
 (s/fdef read-elements
-  :args (s/cat :root-path ::dir-path-or-file)
-  :ret  (s/map-of ::name ::element))
+        :args (s/cat :root-path ::dir-path-or-file)
+        :ret  (s/map-of ::name ::element))
 
 (defn read
   "Pass the path of a dir (must have trailing slash) that contains the dirs
@@ -296,13 +296,13 @@
   (let [model {::systems (read-elements (io/file root-path "systems"))
                ::users (read-elements (io/file root-path "users"))}]
     (if (s/valid? ::model model)
-        model
-        {::anom/category ::anom/fault
-         ::anom/message (expound-str ::model model)
-         ::model model})))
+      model
+      {::anom/category ::anom/fault
+       ::anom/message (expound-str ::model model)
+       ::model model})))
 
 (s/fdef read
-  :args (s/cat :root-path ::dir-path-or-file)
-  :ret  (s/or :success ::model
-              :error   (s/merge ::anom/anomaly
-                                (s/keys :req [::model]))))
+        :args (s/cat :root-path ::dir-path-or-file)
+        :ret  (s/or :success ::model
+                    :error   (s/merge ::anom/anomaly
+                                      (s/keys :req [::model]))))

--- a/test/data/model/systems/division-a/front.yaml
+++ b/test/data/model/systems/division-a/front.yaml
@@ -1,0 +1,1 @@
+name: Front

--- a/test/data/model/systems/division-a/middle.yaml
+++ b/test/data/model/systems/division-a/middle.yaml
@@ -1,0 +1,17 @@
+name: Middle
+uses:
+- container: Mobile
+  system: Back
+- container: Middle
+  system: Internal
+  description: I
+- container: Middle
+  system: Middle
+- container: Back
+  system: Back
+  technology: '3'
+  description: h
+- container: Middle
+  system: Front
+  technology: '29'
+  description: 2b

--- a/test/data/model/systems/division-b/internal.yaml
+++ b/test/data/model/systems/division-b/internal.yaml
@@ -1,0 +1,12 @@
+name: Internal
+description: 3Di9
+containers:
+- name: Front
+  technology: f3jnm
+- name: External
+  description: qBne47S
+- name: Mobile
+  technology: Pzzv
+- name: Mobile
+  technology: ce
+  description: C85

--- a/test/data/model/systems/division-b/mobile.yaml
+++ b/test/data/model/systems/division-b/mobile.yaml
@@ -1,0 +1,89 @@
+name: Mobile
+uses:
+- container: External
+  system: Front
+- container: External
+  system: Mobile
+  description: b6
+  technology: 20f5j
+- container: Back
+  system: External
+- container: Back
+  system: Front
+  description: G
+  technology: Lvmw7Jq
+- container: Front
+  system: Mobile
+  technology: B2V
+- container: External
+  system: Internal
+  technology: 93YJD
+  description: i
+- container: Mobile
+  system: External
+tags:
+- uJfgJ78Yf76qsaR7Nsc
+- s10DUX
+- sP7m9y6f0HQK05J0bvfFVG5gG182b9vRA04SIjMA5Pu
+- 6AJ4bV9YRx
+- Q49ES9u0261bO0WYAneE6FJ7gqaNimlRY3q
+description: m78Cq
+containers:
+- name: Internal
+  technology: 33b
+  description: Rda
+- name: Mobile
+  technology: 0P8x
+  description: 02ok
+- name: Front
+- name: Back
+  uses:
+  - container: Front
+    system: Back
+    description: 35V
+    technology: ub59
+  - container: Mobile
+    system: Middle
+    technology: SX
+  - container: Internal
+    system: Middle
+    description: y8
+    technology: 8g7
+  - container: Back
+    system: Middle
+    description: Q17
+  - container: Internal
+    system: External
+    technology: R
+    description: '56'
+  - container: Mobile
+    system: Mobile
+- name: Back
+  technology: zle
+- name: Back
+  technology: r
+  uses:
+  - container: Back
+    system: Middle
+    description: bl
+    technology: Ur8S7
+  - container: External
+    system: Front
+  - container: Back
+    system: Front
+    technology: x
+  - container: Front
+    system: External
+  - container: Mobile
+    system: Middle
+  - container: Front
+    system: Mobile
+    description: T
+  description: Wsl
+- name: External
+  technology: c5
+- name: External
+- name: Internal
+- name: Front
+  description: LWYhZ
+  technology: z

--- a/test/data/model/systems/external.yaml
+++ b/test/data/model/systems/external.yaml
@@ -1,0 +1,106 @@
+- name: External
+  description: GZ02y3
+  containers:
+  - name: Internal
+    technology: uT
+  - name: Mobile
+    technology: kSJ2xrw
+    description: ersBqah
+  - name: Internal
+    uses:
+    - container: Middle
+      system: Internal
+      description: qi6At
+    - container: Internal
+      system: Internal
+      technology: ZMs
+    - container: Back
+      system: External
+      technology: HaTRry6
+      description: waN88
+    - container: Internal
+      system: External
+    - container: Front
+      system: Mobile
+      description: 53M1Sr
+      technology: bm6W32RpX
+    - container: Front
+      system: Front
+      description: 25D730
+    - container: Back
+      system: External
+      technology: CLhP
+      description: '6'
+    - container: Internal
+      system: Internal
+  - name: Mobile
+    uses:
+    - container: Middle
+      system: Front
+      technology: tZEO4
+    - container: Middle
+      system: Mobile
+      technology: 2cCB
+    - container: Internal
+      system: Mobile
+      description: k63GI
+    - container: Middle
+      system: Internal
+    - container: Back
+      system: Internal
+      description: 0tu4
+    - container: Middle
+      system: External
+    - container: Back
+      system: Front
+      description: B1NyT6Z5
+    - container: External
+      system: Back
+      description: K
+      technology: LEd685bF
+    - container: Mobile
+      system: Mobile
+    - container: Internal
+      system: Middle
+      technology: ghp4
+      description: IvD4xsWay
+  - name: Middle
+    uses:
+    - container: Mobile
+      system: Internal
+      technology: M7Ai
+      description: jzzAAL
+    - container: Middle
+      system: Mobile
+      description: Yob
+    - container: External
+      system: Back
+      description: 9SEYAcK6
+      technology: '3'
+    - container: Middle
+      system: External
+      description: dZ5M6X8F
+    - container: Internal
+      system: Front
+    - container: Middle
+      system: Internal
+      description: oCo
+      technology: Ud2V5w
+    - container: Back
+      system: Mobile
+      description: bxw
+      technology: n8be
+    - container: Back
+      system: Back
+    - container: Mobile
+      system: External
+      technology: Lj4
+    technology: 1JYMc12kG
+    description: 6F5sD9KV
+  - name: Internal
+  repos:
+  - 3KelakVw96uPN05hq5tQlkR7G2Nze746xDb3C
+  - qT0u1609s81zY347v704
+  - vW2m4t8phv76oF00
+  - FH5OoX660Z36jZ8PCQtbtAI22l0Z8NOVlx2V64CmWzWtmQukR
+  - ekE

--- a/test/data/model/users/americas/seller.yaml
+++ b/test/data/model/users/americas/seller.yaml
@@ -1,0 +1,19 @@
+name: Seller (Americas)
+uses:
+- container: Back
+  system: Middle
+  description: TX41
+  technology: Uh3yEW
+- container: Mobile
+  system: Back
+  technology: X0t40140
+  description: c0y
+- container: Front
+  system: Middle
+- container: Mobile
+  system: Mobile
+- container: External
+  system: Internal
+  technology: eCrQai
+  description: 4IUBGC329
+description: v1Z6gH1

--- a/test/data/model/users/dept-that/analyst.yaml
+++ b/test/data/model/users/dept-that/analyst.yaml
@@ -1,0 +1,32 @@
+name: Systems Analyst
+uses:
+- container: Mobile
+  system: Back
+  description: 24I
+- container: Mobile
+  system: Internal
+  technology: 9eY0
+  description: YAwP
+- container: Mobile
+  system: Middle
+  description: 64VW5Uh
+- container: External
+  system: Mobile
+- container: Mobile
+  system: Middle
+  description: 0ADQmvqx7
+- container: Back
+  system: Internal
+- container: Back
+  system: External
+  technology: I8g9wp20
+  description: GG
+- container: External
+  system: Middle
+  description: fkwYqd
+- container: Internal
+  system: Middle
+  technology: J5r3SJ0
+tags:
+- BsC3jV8aOC1Jy3nq4AMjDHLQkh2uXR5X5OO9
+- 2G52p4vdlRP3WvMP7hheAnEHX98ly8sq

--- a/test/data/model/users/dept-this/support.yaml
+++ b/test/data/model/users/dept-this/support.yaml
@@ -1,0 +1,37 @@
+name: Support Technician
+tags:
+- aV80zK1459wFA7up9J0bgVkN
+- 2zpT655nvBR7X1KO31aXMM47RoCTfbcjg8083mD
+- il4d5vk83X6BnyNl9566HsbQ3hc277147Ze6nnjJ3WwA
+- 7F6z4YtRdx33HmBreOaGXWROVnpNVVQ76oH2Jk9p2
+- B2c3qXRn242vTZM6IONn8zbNeantwIeG0D3tFJ5IE
+- 68mYTIZ
+- R1
+- riOHp06dchCswRqz6W3n65
+uses:
+- container: Middle
+  system: Front
+  technology: 8B1f
+  description: '0'
+- container: External
+  system: External
+  description: C
+- container: Front
+  system: External
+  description: '5'
+  technology: h4m
+- container: Mobile
+  system: Mobile
+  description: h1E
+  technology: DE
+- container: Middle
+  system: External
+  technology: T
+  description: i7
+- container: Back
+  system: Mobile
+  description: P
+  technology: E
+- container: External
+  system: Mobile
+  description: 1JN

--- a/test/data/model/users/external.yaml
+++ b/test/data/model/users/external.yaml
@@ -1,0 +1,74 @@
+- name: Direct Customer
+  tags:
+  - 5Akh8d9acezQ1s99vG5B8MzezbS9D451kgzvD
+  - AUU56bH1YI9ySZu6MoIEJjV28M6t81FTFlt
+  - PsdiEL7OgtbhfSK75IcTD4AuIeV9FD8ql4sJ3SG5t3cUaQ8
+  - 44fKWgAcMPo8fvt0N91pk4hnY6K08s1QcnG54w6jn
+  - oh0AFRbtsgqeC64pJEBFA7z9N6ti838
+  - IR9wUfQ83iYlFZxcT1KV02Y57e799
+  - FYAyTg7rSA5gBY6OC9B49X78458USPb2uC10QT984LEEj
+  description: c
+  uses:
+  - container: Middle
+    system: Back
+    description: XM
+  - container: Internal
+    system: Front
+    technology: 5N
+    description: '1'
+  - container: Back
+    system: Back
+    description: u
+    technology: X
+  - container: Internal
+    system: Front
+    technology: '0'
+    description: d
+  - container: Back
+    system: Back
+    technology: XF
+    description: 5p
+  - container: Mobile
+    system: Front
+  - container: Middle
+    system: Front
+    technology: Xt
+  - container: Mobile
+    system: Internal
+    technology: M
+    description: 02w
+  - container: Internal
+    system: Internal
+    description: m
+  - container: Back
+    system: Mobile
+    technology: '0'
+    description: '8'
+- name: Broker Customer
+  uses:
+  - container: Middle
+    system: Mobile
+  - container: Middle
+    system: Internal
+    technology: 36h
+    description: GOr
+  - container: Back
+    system: Back
+    description: Qn
+  - container: External
+    system: Back
+    description: N
+    technology: Wb0r
+  - container: Middle
+    system: Back
+  tags:
+  - 9uI632q90BXYo6J9387310FeP4cOSa86vu
+  - kSNmStu34th7tXw1lCRRzyUT2jsRmhBY0
+  - 9IF5meymP
+  - 58TF36rj0o6S
+  - bx0NWSQA5q
+  - 7eav9yc5U0RVA4K6U72N7kPz4B3Tgn2A40WmyAI3
+  - Y5ULfrmZzrD11DikP4q57L0ikrF31nDF8rLo61d6
+  - SU6nI3Ksq6HGx9i4
+  - DXXzb12o6Bf6uvnYQ
+  description: I

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -6,6 +6,7 @@
             [fc4c.test-utils :refer [check]]))
 
 (deftest add-ns (check `m/add-ns 100))
+(deftest fixup-element (check `m/fixup-element 100))
 (deftest get-tags-from-path (check `m/get-tags-from-path 100))
 (deftest qualify-keys (check `m/qualify-keys 100))
 (deftest to-set-of-keywords (check `m/to-set-of-keywords 100))

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -1,8 +1,11 @@
 (ns fc4c.model-test
-  (:require [clojure.test :refer [deftest]]
+  (:refer-clojure :exclude [read])
+  (:require [clojure.spec.alpha :as s]
+            [clojure.test :refer [deftest is]]
             [fc4c.model :as m]
             [fc4c.test-utils :refer [check]]))
 
+;;;; Generative Tests
 (deftest add-ns (check `m/add-ns 500))
 (deftest elements-from-file (check `m/elements-from-file 100))
 (deftest fixup-element (check `m/fixup-element 100))
@@ -10,3 +13,6 @@
 (deftest qualify-keys (check `m/qualify-keys 100))
 (deftest to-set-of-keywords (check `m/to-set-of-keywords))
 (deftest update-all (check `m/update-all 100))
+
+;;;; Example Tests
+(deftest read (is (s/valid? ::m/model (m/read "test/data/model"))))

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -6,18 +6,9 @@
             [fc4c.test-utils :refer [check]]))
 
 (deftest add-ns (check `m/add-ns 100))
+(deftest elements-from-file (check `m/elements-from-file 100))
 (deftest fixup-element (check `m/fixup-element 100))
 (deftest get-tags-from-path (check `m/get-tags-from-path 100))
 (deftest qualify-keys (check `m/qualify-keys 100))
 (deftest to-set-of-keywords (check `m/to-set-of-keywords 100))
 (deftest update-all (check `m/update-all 100))
-
-;; If you’re wondering why there’s no tests for m/read, m/read-elements, and
-;; m/elements-from-file, it’s because those functions do I/O (they read YAML
-;; files from disk and conver them into elements and a model) and we can’t do
-;; generative testing with them. We _can_ do “example testing” with them, i.e.
-;; more traditional unit tests, by simply adding a bunch of YAML files to our
-;; test suite and having tests that point those functions to them, then validate
-;; the results. And we probably *will* do that. But first, these functions need
-;; to be refactored a bit to more properly separate I/O from computation — to
-;; “move IO to the edges”.

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -1,0 +1,20 @@
+(ns fc4c.model-test
+  (:refer-clojure :exclude [read])
+  (:require [clojure.test :refer [deftest]]
+            [expound.alpha :as expound :refer [explain-results]]
+            [fc4c.model :as m]
+            [fc4c.test-utils :refer [check]]))
+
+(deftest add-ns (check `m/add-ns 10))
+(deftest add-tags (check `m/add-tags 10))
+(deftest qualify-keys (check `m/qualify-keys 10))
+
+;; If you’re wondering why there’s no tests for m/read, m/read-elements, and
+;; m/elements-from-file, it’s because those functions do I/O (they read YAML
+;; files from disk and conver them into elements and a model) and we can’t do
+;; generative testing with them. We _can_ do “example testing” with them, i.e.
+;; more traditional unit tests, by simply adding a bunch of YAML files to our
+;; test suite and having tests that point those functions to them, then validate
+;; the results. And we probably *will* do that. But first, these functions need
+;; to be refactored a bit to more properly separate I/O from computation — to
+;; “move IO to the edges”.

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -5,9 +5,11 @@
             [fc4c.model :as m]
             [fc4c.test-utils :refer [check]]))
 
-(deftest add-ns (check `m/add-ns 10))
-(deftest add-tags (check `m/add-tags 10))
-(deftest qualify-keys (check `m/qualify-keys 10))
+(deftest add-ns (check `m/add-ns 100))
+(deftest get-tags-from-path (check `m/get-tags-from-path 100))
+(deftest qualify-keys (check `m/qualify-keys 100))
+(deftest to-set-of-keywords (check `m/to-set-of-keywords 100))
+(deftest update-all (check `m/update-all 100))
 
 ;; If you’re wondering why there’s no tests for m/read, m/read-elements, and
 ;; m/elements-from-file, it’s because those functions do I/O (they read YAML

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -1,14 +1,12 @@
 (ns fc4c.model-test
-  (:refer-clojure :exclude [read])
   (:require [clojure.test :refer [deftest]]
-            [expound.alpha :as expound :refer [explain-results]]
             [fc4c.model :as m]
             [fc4c.test-utils :refer [check]]))
 
-(deftest add-ns (check `m/add-ns 100))
+(deftest add-ns (check `m/add-ns 500))
 (deftest elements-from-file (check `m/elements-from-file 100))
 (deftest fixup-element (check `m/fixup-element 100))
-(deftest get-tags-from-path (check `m/get-tags-from-path 100))
+(deftest get-tags-from-path (check `m/get-tags-from-path))
 (deftest qualify-keys (check `m/qualify-keys 100))
-(deftest to-set-of-keywords (check `m/to-set-of-keywords 100))
+(deftest to-set-of-keywords (check `m/to-set-of-keywords))
 (deftest update-all (check `m/update-all 100))


### PR DESCRIPTION
I know the PR stats make this look big, but it’s mostly test data in YAML files. In terms of code there’s “only” ~240 new lines.

Background from the (private within Funding Circle) ticket:

> Currently with FC4, we have only a single kind of data structure: a diagram. It defines both the systems and their elements and all the relationships thereof, and how those should all be depicted in a specific view.
> 
> This is very straightforward in the sense that we end up with a 1:1 correlation between YAML file and PNG file, and we have only one kind of file/structure: a diagram.
> 
> But! It has a bunch of downsides:
> 
> * Requires lots of duplication and repetition
>   * e.g. a container diagram is a superset of the same system’s context
>     diagram
>   * e.g. the same element may appear in multiple files, and its content
>     (data) (e.g. description) need to be repeated each time
> * That duplication and repetition leads to too much busywork to keep
>   things in sync, and too much risk that things will drift
> 
> Really, each thing should be defined/described/stated in one single time+place. A “single source of truth” — look at that, that idea pops up
> _everywhere!_
> 
> So let’s try embracing one of the aspects of
> [Structurizr](https://structurizr.com/) that I had initially dismissed: defining the _model_ of one’s systems independently of the _views_ of those systems.
> 
> Concretely, this would mean that instead of a single dir tree containing simply _diagrams_, we’d have a bifurcated tree containing the _model_ and the _views_ (or perhaps we should simply call the views _diagrams_).

This PR specifies the data structure and YAML file-format for capturing the model of a system landscape: a set of interrelated systems and users. It also includes functions for reading the model from those YAML files on disk — in a specific directory structure — and validating the model once it’s been read.

(Ideally this would include changes to the docs, to describe the new directory structure, file formats, etc. I’m holding off on that for now though, because those changes would make the most sense to be applied to the “methodology” documentation in the fc4-framework repo. I recently concluded that these two repos need to be unified; I plan to move the tool(s) herein to a new dir named `tools` in the framework repo, unifying the framework with its docs and tools in a single repo. This will also resolve the question of this tool(set) needing a new name: it’ll just be _FC4 Tools_ or in code `fc4.tools.*`)