### PR TITLE
 Switch test runner to eftest for faster tests and builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
        - run:
           name: Download dependencies (if necessary)
           # Clojure automatically downloads deps if necessary
-          command: "clojure -R:run-tests:coverage:lint -e '(println \"deps are installed!\")'"
+          command: "clojure -R:test:test/run:coverage:lint -e '(println \"deps are installed!\")'"
 
        - save_cache:
            key: dependencies-{{ checksum "deps.edn" }}
@@ -28,7 +28,10 @@ jobs:
           # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8
           # defaults to setting the max heap to ¼ of the total RAM, and CI containers frequently have
           # <= 4GB RAM.)
-          command: "clojure -J-Xmx2g -A:run-tests"
+          command: "clojure -J-Xmx2g -A:test:test/run"
+
+       - store_test_results:
+          path: target/test-results
 
        - run:
           name: Measure test coverage
@@ -37,7 +40,7 @@ jobs:
           # this, but it doesn’t actually matter, so for now we just suppress it. The real problem
           # with this is that it prevents the build from failing if the coverage is below the minimum
           # threshold (as specified in the coverage profile in deps.edn).
-          command: "clojure -J-Xmx2g -A:coverage || true"
+          command: "clojure -J-Xmx2g -A:test:coverage || true"
 
        - store_artifacts:
           path: target/coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ COPY . ./
 
 # The max heap size is set to 2GB because I’ve seen OOM errors at 1GB and below. (JDK 8 defaults to
 # setting the max heap to ¼ of the total RAM, and containers frequently have <= 4GB RAM.)
-ENTRYPOINT clojure -J-Xmx2g -A:run-tests
+ENTRYPOINT clojure -J-Xmx2g -A:test:test/run

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ docker run --rm `docker build -q .`
 
 If you’re old-school and prefer to run tests on bare metal:
 
-1. Have `clj` installed ([guide](https://clojure.org/guides/getting_started))
-1. Run in your shell: `clojure -A:run-tests`
+1. Have `clojure` installed ([guide](https://clojure.org/guides/getting_started))
+1. Run in your shell: `clojure -A:test:test/run`
 
 ## Starting a REPL for Dev/Test
 
-You could just run `clj` but you’re likely to want the test deps and code to be accessible. In that
-case run `clj -Adev`
+You _could_ just run `clj` but you’re likely to want the test deps and dev utils to be accessible.
+So you’ll probably want to run `clj -A:test:dev`
 
 ## Running the Linter
 

--- a/deps.edn
+++ b/deps.edn
@@ -11,24 +11,16 @@
   ;; but worth it.
   com.gfredericks/test.chuck {:mvn/version "0.2.9"}}
 
- :aliases {:dev       {:extra-paths ["test"]
-                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     org.clojure/tools.trace    {:mvn/version "0.7.9"}
+ :aliases {:test      {:extra-paths ["test"]
+                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.10.0-alpha3"}
+                                     eftest                     {:mvn/version "0.5.2"}}}
+
+           :test/run  {:main-opts   ["-m" "fc4c.test"]}
+
+           :dev       {:extra-deps  {org.clojure/tools.trace    {:mvn/version "0.7.9"}
                                      inspectable                {:mvn/version "0.2.2"}}}
 
-           :run-tests {:extra-paths ["test"]
-                       :extra-deps  {org.clojure/test.check     {:mvn/version "0.9.0"}
-                                     ;; This is a fork of com.cognitect/test-runner that returns a
-                                     ;; non-zero status when tests fail; this is crucial when
-                                     ;; building in a CI environment.
-                                     ;; See https://github.com/cognitect-labs/test-runner/pull/12
-                                     github-Olical/test-runner
-                                     {:git/url "https://github.com/Olical/test-runner"
-                                      :sha     "7c4f5bd4987ec514889c7cd7e3d13f4ef95f256b"}}
-                       :main-opts   ["-m" "cognitect.test-runner"]}
-
-           :coverage  {:extra-paths ["test"]
-                       :extra-deps  {cloverage                  {:mvn/version "1.0.10"}}
+           :coverage  {:extra-deps  {cloverage                  {:mvn/version "1.0.10"}}
                        :main-opts   ["-m" "cloverage.coverage"
                                      ;; TODO: make this regex exclude fc4c.test-utils
                                      "--ns-regex" "^fc4c.+(?<!test)"

--- a/src/fc4c/test.clj
+++ b/src/fc4c/test.clj
@@ -1,0 +1,37 @@
+(ns fc4c.test
+  "This works just fine for local dev/test use cases but is also fine-tuned to
+  serve our needs when run in this project’s CI service (CircleCI)."
+  (:require [eftest.report          :as report :refer [report-to-file]]
+            [eftest.report.progress :as progress]
+            [eftest.report.junit    :as ju]
+            [eftest.runner          :as runner :refer [find-tests run-tests]]))
+
+;; TODO add an option to measure coverage with Cloverage.
+;;    see: https://github.com/weavejester/eftest/issues/50
+
+(def test-dir "test")
+(def output-path
+  "This is optimized for CircleCI: https://circleci.com/docs/2.0/configuration-reference/#store_test_results"
+  "target/test-results/eftest/results.xml")
+
+(defn- multi-report
+  "Accepts n reporting functions, returns a reporting function that will call
+  them all for their side effects and return nil. I tried to just use juxt but
+  it didn’t work. Maybe because some of the reporting functions provided by
+  eftest are multimethods, I don’t know."
+  [& fs]
+  (fn [event]
+    (doseq [f fs]
+      (f event))))
+
+(defn -main []
+  (let [tests (find-tests test-dir)
+        report-to-file-fn (report-to-file ju/report output-path)
+        report-fn (multi-report progress/report report-to-file-fn)
+        opts {:report report-fn}
+        results (run-tests tests opts)
+        exit-code (->> (select-keys results [:fail :error])
+                       vals
+                       (reduce +))]
+    (shutdown-agents)
+    (System/exit exit-code)))

--- a/src/fc4c/test.clj
+++ b/src/fc4c/test.clj
@@ -39,8 +39,9 @@
 (defn -main []
   (let [tests (find-tests test-dir)
         results (run-tests tests opts)
-        exit-code (->> (select-keys results [:fail :error])
-                       vals
-                       (reduce +))]
+        unsuccessful-tests (->> (select-keys results [:fail :error])
+                                (vals)
+                                (reduce +))
+        exit-code (if (zero? unsuccessful-tests) 0 1)]
     (shutdown-agents)
     (System/exit exit-code)))


### PR DESCRIPTION
Our tests are computationally bound and the prior test runner was
running them sequentially. This is silly, since most machines used by
developers and CI are multi-core. Since [eftest](https://github.com/weavejester/eftest) runs tests across
multiple threads by default, I thought it might work well to address
this — and it does! On my machine, wall-clock time to run the tests
drops from ~66 seconds to ~32 seconds.

I had to upgrade test.check from the latest stable release, 0.9.0, to
the latest alpha release, 0.10.0-alpha3, as there’s some incompatibility
between 0.9.0 and eftest. See https://github.com/weavejester/eftest/issues/32

As long as I was writing custom test running code, I thought I may as
well have it product a JUnit XML file as well, so CircleCI can analyze
and render test stats. Turns out eftest made this real easy. Nice.

Having our own custom test runner should also make it easy to integrate
the measurement of test/code coverage into the test runs.

This eftest ticket should point the way towards that:
  https://github.com/weavejester/eftest/issues/50

Even if the requested feature isn’t implemented in eftest, the linked
commit in the CircleCI test runner (circleci.test) may show how we can
do the same.