### PR TITLE
Add missing require to fc4c.repl and thereby fix coverage measurements

### DIFF
--- a/src/fc4c/repl.clj
+++ b/src/fc4c/repl.clj
@@ -2,8 +2,9 @@
   "Import some useful funcs for using FC4C from the REPL into this single
   namespace, for convenience."
   (:require [clojure.repl :as cr]
-            [fc4c.integrations.structurizr.express.clipboard :as cb]
             [fc4c.files :as rf]
+            [fc4c.integrations.structurizr.express.clipboard :as cb]
+            [fc4c.io :as fio]
             [potemkin :refer [import-vars]]))
 
 ;; Make convenience functions readily accessible.


### PR DESCRIPTION
I had moved a function from one namespace to another and forgotten to
add a require of the new namespace, which caused potemkin’s import-vars
to choke on the var I was trying to import, because the new namespace
hadn’t been loaded.

I didn’t notice this so I guess I haven’t been using this namespace
lately, and it has no tests 😬. This was causing the coverage step in
the CI builds to fail, but there’s a `|| true` in the CI command due to
a test that always fails when measuring coverage, for some unknown
reason — see the comment in `.circleci/config.yml` for more. So the only
reason I noticed that the coverage step was failing was because the
CI builds were suddenly much faster — which was nice, actually 😬. I
look forward to integrating the coverage measurement into the
test-running step (which should be possible now).