### PR TITLE
New data structure + file format for FC4 Views

### DIFF
--- a/src/fc4c/integrations/structurizr/express/edit.clj
+++ b/src/fc4c/integrations/structurizr/express/edit.clj
@@ -2,6 +2,7 @@
   "Functions that assist with editing Structurizr Express diagrams, which are
   serialized as YAML documents."
   (:require [fc4c.integrations.structurizr.express.spec :as ss]
+            [fc4c.spec :as fs]
             [clj-yaml.core :as yaml]
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
@@ -145,7 +146,7 @@
    diagram
    desired-order))
 
-(def coord-pattern (re-pattern (str "^" ss/coord-pattern-base "$")))
+(def coord-pattern (re-pattern (str "^" fs/coord-pattern-base "$")))
 
 (defn parse-coords [s]
   (some->> s
@@ -154,7 +155,7 @@
            (map #(Integer/parseInt %))))
 
 (s/fdef parse-coords
-        :args (s/cat :s :structurizr/coord-string)
+        :args (s/cat :s ::fs/coord-string)
         :ret (s/coll-of :structurizr/coord-int :count 2)
         :fn (fn [{:keys [ret args]}]
               (= ret
@@ -200,7 +201,7 @@
         :args (s/cat :coords (s/coll-of nat-int? :count 2)
                      :to-closest nat-int?
                      :min-margin nat-int?)
-        :ret :structurizr/coord-string
+        :ret ::fs/coord-string
         :fn (fn [{:keys [ret args]}]
               (let [parsed-ret (parse-coords ret)
                     {:keys [:to-closest :min-margin]} args]

--- a/src/fc4c/integrations/structurizr/express/spec.clj
+++ b/src/fc4c/integrations/structurizr/express/spec.clj
@@ -9,14 +9,6 @@
 
 (s/def :structurizr/tags ::fs/non-blank-simple-str) ;; comma-delimited TODO: use a regex
 
-(def coord-pattern-base "(\\d{1,4}), ?(\\d{1,4})")
-
-(s/def :structurizr/coord-string
-  (s/with-gen string?
-    ;; unfortunately we can’t use coord-pattern here because it has anchors
-    ;; which are not supported by string-from-regex.
-    #(gen'/string-from-regex (re-pattern coord-pattern-base))))
-
 (s/def :structurizr/coord-int
   ;; The upper bound here was semi-randomly chosen; we just need a reasonable number that a real
   ;; diagram is unlikely to ever need but that won’t cause integer overflows when multiplied.
@@ -25,7 +17,7 @@
   ;; during generative testing.
   (s/int-in 0 50001))
 
-(s/def :structurizr/position :structurizr/coord-string)
+(s/def :structurizr/position ::fs/coord-string)
 
 (def int-pattern #"\d{1,6}")
 (s/def :structurizr/int-in-string
@@ -53,7 +45,7 @@
 (s/def :structurizr.relationship/source :structurizr/name)
 (s/def :structurizr.relationship/destination :structurizr/name)
 (s/def :structurizr.relationship/order :structurizr/int-in-string)
-(s/def :structurizr.relationship/vertices (s/coll-of :structurizr/coord-string :min-count 1))
+(s/def :structurizr.relationship/vertices (s/coll-of :structurizr/position :min-count 1))
 
 (s/def :structurizr/relationship
   (s/keys :req-un [:structurizr.relationship/source :structurizr.relationship/destination]

--- a/src/fc4c/io.clj
+++ b/src/fc4c/io.clj
@@ -11,7 +11,8 @@
             [fc4c.files              :as files :refer [relativize]]
             [fc4c.model              :as m :refer [elements-from-file]]
             [fc4c.spec               :as fs]
-            [fc4c.util               :as u :refer [lookup-table-by]]))
+            [fc4c.util               :as u :refer [lookup-table-by]]
+            [fc4c.view               :as v :refer [view-from-file]]))
 
 (defn yaml-files
   "Accepts a directory as a path string or a java.io.File, returns a lazy sequence of java.io.File objects for
@@ -77,3 +78,18 @@
         :ret  (s/or :success ::m/model
                     :error   (s/merge ::anom/anomaly
                                       (s/keys :req [::m/model]))))
+
+(defn read-view
+  [file-path]
+  (let [view (view-from-file (slurp file-path))]
+    (if (s/valid? ::v/view view)
+      view
+      {::anom/category ::anom/fault
+       ::anom/message (expound-str ::v/view view)
+       ::v/view view})))
+
+(s/fdef read-view
+        :args (s/cat :file-path ::fs/file-path-str)
+        :ret  (s/or :success ::v/view
+                    :error   (s/merge ::anom/anomaly
+                                      (s/keys :req [::v/view]))))

--- a/src/fc4c/spec.clj
+++ b/src/fc4c/spec.clj
@@ -3,7 +3,8 @@
   (:require [clojure.java.io :as io] ; used to generate File "values" not do IO
             [clojure.spec.alpha :as s]
             [clojure.spec.gen.alpha :as gen]
-            [clojure.string :refer [blank? ends-with? includes? join]]))
+            [clojure.string :refer [blank? ends-with? includes? join]]
+            [com.gfredericks.test.chuck.generators :as gen']))
 
 (s/def ::non-blank-str (s/and string? (complement blank?)))
 (s/def ::no-linebreaks  (s/and string? #(not (includes? % "\n"))))
@@ -21,6 +22,17 @@
       (s/and ::non-blank-simple-str
              #(<= min (count %) max))
       #(str-gen min max))))
+
+(s/def ::unqualified-keyword
+  (s/with-gen
+    (s/and keyword? (complement qualified-keyword?))
+    #(gen/fmap keyword (s/gen ::non-blank-simple-str))))
+
+(def coord-pattern-base "(\\d{1,4}), ?(\\d{1,4})")
+
+(s/def ::coord-string
+  (s/with-gen string?
+    #(gen'/string-from-regex (re-pattern coord-pattern-base))))
 
 (s/def ::file-path-str
   (s/with-gen

--- a/src/fc4c/util.clj
+++ b/src/fc4c/util.clj
@@ -1,4 +1,7 @@
-(ns fc4c.util)
+(ns fc4c.util
+  (:require [clojure.walk        :as walk  :refer [postwalk]]
+            [clojure.spec.alpha  :as s]
+            [fc4c.spec           :as fs]))
 
 (defn lookup-table-by
   "Given a function and a seqable, returns a map of (f x) to x.
@@ -8,3 +11,54 @@
   {:foo {:name :foo}, :bar {:name :bar}}"
   [f xs]
   (zipmap (map f xs) xs))
+
+(defn add-ns
+  [namespace keeword]
+  (keyword (name namespace) (name keeword)))
+
+(s/def ::keyword-or-simple-string
+  (s/or :keyword keyword?
+        :string  ::fs/non-blank-simple-str))
+
+(s/fdef add-ns
+        :args (s/cat :namespace ::keyword-or-simple-string
+                     :keyword   ::keyword-or-simple-string)
+        :ret  qualified-keyword?)
+
+(defn update-all
+  "Given a map and a function of entry (coll of two elems) to entry, applies the
+  function recursively to every entry in the map."
+  {:fork-of 'clojure.walk/stringify-keys}
+  [f m]
+  (postwalk
+   (fn [x]
+     (if (map? x)
+       (into {} (map f x))
+       x))
+   m))
+
+(s/def ::map-entry
+  (s/tuple any? any?))
+
+(s/fdef update-all
+        :args (s/cat :fn (s/fspec :args (s/cat :entry ::map-entry)
+                                  :ret  ::map-entry)
+                     :map map?)
+        :ret  map?)
+
+(defn qualify-keys
+  "Given a nested map with keyword keys, qualifies all keys, recursively, with
+  the current namespace."
+  [m ns-name]
+  (update-all
+   (fn [[k v]]
+     (if (and (keyword? k)
+              (not (qualified-keyword? k)))
+       [(add-ns ns-name k) v]
+       [k v]))
+   m))
+
+(s/fdef qualify-keys
+        :args (s/cat :map (s/map-of keyword? any?)
+                     :ns-name ::fs/non-blank-simple-str)
+        :ret  (s/map-of qualified-keyword? any?))

--- a/src/fc4c/view.clj
+++ b/src/fc4c/view.clj
@@ -1,0 +1,62 @@
+(ns fc4c.view
+  (:require [clj-yaml.core           :as yaml]
+            [clojure.spec.alpha      :as s]
+            [clojure.spec.gen.alpha  :as gen]
+            [fc4c.spec               :as fs]
+            [fc4c.util               :as util]))
+
+(load "view_specs")
+
+(defn- fixup-keys
+  "Finds any keyword keys that contain spaces and/or capital letters and
+  replaces them with their string versions, because any such value is likely to
+  be an element name, and we need those to be strings."
+  [view]
+  (util/update-all
+   (fn [[k v]]
+     (if (and (keyword? k)
+              (re-seq #"[A-Z ]" (name k)))
+       [(name k) v]
+       [k v]))
+   view))
+
+(s/fdef fixup-keys
+        :args (s/cat :m (s/map-of ::fs/unqualified-keyword any?))
+        :ret  (s/map-of (s/or :keyword keyword? :string string?) any?)
+        :fn   (fn [{{m :m} :args, ret :ret}]
+                (and (= (count m) (count ret))
+                     (empty? (->> (keys ret)
+                                  (filter keyword?)
+                                  (map name)
+                                  (filter #(re-seq #"[A-Z ]" %)))))))
+
+; We have to capture this at compile time in order for it to have the value we
+; want it to; if we referred to *ns* in the body of a function then, because it
+; is dynamically bound, it would return the namespace at the top of the stack,
+; the “currently active namespace” rather than what we want, which is the
+; namespace of this file, because that’s the namespace all our keywords are
+; qualified with.
+(def ^:private this-ns-name (str *ns*))
+
+(defn view-from-file
+  "Parses the contents of a YAML file, then processes those contents such that
+  each element conforms to ::view."
+  [file-contents]
+  (-> (yaml/parse-string file-contents)
+      ;; Both the below functions do a walk through the view; this is
+      ;; redundant, duplicative, inefficient, and possibly slow. So this right
+      ;; here is a potential spot for optimization.
+      (fixup-keys)
+      (util/qualify-keys this-ns-name)))
+
+(s/def ::yaml-file-contents
+  (s/with-gen
+    ::fs/non-blank-str
+    #(gen/fmap yaml/generate-string (s/gen ::view))))
+
+(s/fdef view-from-file
+        :args (s/cat :file-contents ::yaml-file-contents)
+        :ret  ::view
+        :fn   (fn [{{:keys [file-contents]} :args, ret :ret}]
+                (= file-contents
+                   (yaml/generate-string ret))))

--- a/src/fc4c/view_specs.clj
+++ b/src/fc4c/view_specs.clj
@@ -1,0 +1,54 @@
+(ns fc4c.view
+  (:require [clojure.spec.alpha  :as s]
+            [fc4c.model          :as m]
+            [fc4c.spec           :as fs]))
+
+(s/def ::description ::fs/non-blank-str) ;; Could reasonably have linebreaks.
+
+;; We need that generator! See comment in definition of ::m/name.
+(s/def ::name ::m/name)
+(s/def ::system ::m/name)
+
+;; You might ask: why copy specs over from a different namespace? It’s because
+;; when the views are parsed from YAML files and we end up with non-namespaced
+;; keyword keys, and we then post-process them to qualify them with namespaces,
+;; it’s impractical to qualify them with _different_ namespaces, so we’re going
+;; to qualify them all with _the same_ namespace. Thus, that namespace needs to
+;; include definitions for -all- the keys that appear in the YAML files.
+(s/def ::coord-string ::fs/coord-string)
+
+(s/def ::subject ::coord-string)
+(s/def ::position-map (s/map-of ::name ::coord-string :min-count 1))
+(s/def ::users ::position-map)
+(s/def ::containers ::position-map)
+(s/def ::other-systems ::position-map)
+
+(s/def ::positions
+  (s/and
+   (s/keys
+    :req [::subject]
+    :opt [::users ::containers ::other-systems])
+   #(some (partial contains? %) [::users ::containers ::other-systems])))
+
+(s/def ::control-point-group
+  (s/map-of
+   ::name
+   (s/coll-of (s/coll-of ::coord-string :min-count 1 :gen-max 3)
+              :min-count 1
+              :gen-max 3)
+   :min-count 1
+   :gen-max 3))
+
+(s/def ::system-context ::control-point-group)
+(s/def ::container ::control-point-group)
+
+(s/def ::control-points
+  (s/keys
+   :req [::system-context]
+   :opt [::container]))
+
+(s/def ::size :structurizr.diagram/size)
+
+(s/def ::view
+  (s/keys
+   :req [::system ::description ::positions ::control-points ::size]))

--- a/test/data/views/middle.yaml
+++ b/test/data/views/middle.yaml
@@ -1,0 +1,12 @@
+system: Middle
+description: Ao
+positions:
+  subject: 3, 7
+  containers: {Front: '3, 9', Internal: '16, 13', Back: '001,5'}
+  other-systems: {Mobile: '4,9593', External: '59,234', Back: '5,811', Front: '74, 67', Internal: '88,8'}
+control-points:
+  system-context:
+    Front:
+    - ['196, 73', '169,48', '446,59']
+    - ['79,3', '559, 6770', '19, 9396']
+size: A3_Landscape

--- a/test/fc4c/io_test.clj
+++ b/test/fc4c/io_test.clj
@@ -2,6 +2,11 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.test :refer [deftest is]]
             [fc4c.io :as io]
-            [fc4c.model :as m]))
+            [fc4c.model :as m]
+            [fc4c.view :as v]))
 
-(deftest read-model (is (s/valid? ::m/model (io/read-model "test/data/model"))))
+(deftest read-mode
+  (is (s/valid? ::m/model (io/read-model "test/data/model"))))
+
+(deftest read-view
+  (is (s/valid? ::v/view (io/read-view "test/data/views/middle.yaml"))))

--- a/test/fc4c/model_test.clj
+++ b/test/fc4c/model_test.clj
@@ -3,10 +3,7 @@
             [fc4c.model :as m]
             [fc4c.test-utils :refer [check]]))
 
-(deftest add-ns (check `m/add-ns 500))
 (deftest elements-from-file (check `m/elements-from-file 100))
 (deftest fixup-element (check `m/fixup-element 100))
 (deftest get-tags-from-path (check `m/get-tags-from-path))
-(deftest qualify-keys (check `m/qualify-keys 100))
 (deftest to-set-of-keywords (check `m/to-set-of-keywords))
-(deftest update-all (check `m/update-all 100))

--- a/test/fc4c/util_test.clj
+++ b/test/fc4c/util_test.clj
@@ -1,0 +1,8 @@
+(ns fc4c.util-test
+  (:require [clojure.test :refer [deftest is]]
+            [fc4c.util :as u]
+            [fc4c.test-utils :refer [check]]))
+
+(deftest add-ns (check `u/add-ns 500))
+(deftest qualify-keys (check `m/qualify-keys 100))
+(deftest update-all (check `m/update-all 100))

--- a/test/fc4c/view_test.clj
+++ b/test/fc4c/view_test.clj
@@ -1,0 +1,7 @@
+(ns fc4c.view-test
+  (:require [clojure.test :refer [deftest is]]
+            [fc4c.view :as v]
+            [fc4c.test-utils :refer [check]]))
+
+(deftest view-from-file (check `v/view-from-file 1000))
+(deftest fixup-keys (check `v/fixup-keys 1000))


### PR DESCRIPTION
Building on 97e611c78 this introduces a new data structure and file
format for defining System Context diagrams and Container diagrams that
can be exported to Structurizr Express (SE) format. After this we just
need a data struct + file format for styles, and then we’ll be able to
move on to exporting these views to SE diagrams.