### PR TITLE
Update methodology and readme with new tool name

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It builds on [the C4 Model](https://c4model.com/) and [Structurizr Express](http
 It has two components:
 
 * [the methodology](methodology/README.md)
-* the tool: [FC4C](https://github.com/FundingCircle/fc4c)
+* [fc4-tool](tool/README.md)
 
 It originated at and is maintained by [Funding Circle](https://engineering.fundingcircle.com/).
 
@@ -15,9 +15,9 @@ To get started, we recommend reading [the methodology](methodology/README.md). I
 
 ## The Name
 
-FC4 is not ([yet](https://en.wikipedia.org/wiki/Backronym)) an acronym or initialism; it doesn’t stand for anything — it’s “just” a name. (This is also true of the name of [FC4C](https://github.com/FundingCircle/fc4c).)
+FC4 is not ([yet](https://en.wikipedia.org/wiki/Backronym)) an acronym or initialism; it doesn’t stand for anything — it’s “just” a name.
 
-The name is a combination of “FC” and “C4” — the former is a reference to Funding Circle, the originating context of the framework; the latter to Simon Brown’s C4 model,  the foundation of the framework.
+The name is a combination of “FC” and “C4” — the former is a reference to Funding Circle, the originating context of the framework; the latter to Simon Brown’s C4 model, the foundation of the framework.
 
 ## Contributing
 

--- a/methodology/authoring_workflow.md
+++ b/methodology/authoring_workflow.md
@@ -8,20 +8,18 @@ Once a basic YAML file has been created with some initial contents, the basic au
 
 1. Create a new git branch in your local instance of [the diagram repository](repository.md)
 1. In your text editor: either create a new diagram source file or open an existing diagram source file
-1. In a terminal, in your FC4C working dir:
-   1. Open a Clojure REPL with `clj`
-   1. Evaluate `(use 'fc4c.repl')` then `(wcb)`
-   1. This starts a background process that will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
+1. In a terminal, in your `fc4` working dir, run `cd tool && ./wcb`
+   1. This starts the tool in a mode wherein it will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
 1. In your text editor, add/revise elements and relationships, then select-all and cut the diagram source from your editor into your system clipboard.
-   1. This will cause FC4C to process the contents of your clipboard.
+   1. This will cause fc4-tool to process the contents of your clipboard.
 1. Switch to [Structurizr Express](https://structurizr.com/help/express) (SE) » paste the source into the YAML textarea » press tab to blur the textarea
    1. SE will either render the diagram, or display a red error indicator in its toolbar
    2. If SE shows its red error indicator, click the indicator button to bring up a dialog listing the errors
 1. Use SE to arrange the elements and edges as desired
 1. Cut the diagram source from the SE YAML textarea into your system clipboard.
-   1. This will cause FC4C to process the contents of your clipboard.
+   1. This will cause fc4-tool to process the contents of your clipboard.
 1. Paste the diagram source back into the SE YAML textarea so as to re-render the diagram, now that the elements have been “snapped” to a virtual grid.
-1. Continue to cut and past the diagram source between your text editor and SE, using SE to preview and adjust the rendered diagram, while FC4C cleans up the diagram as you work.
+1. Continue to cut and past the diagram source between your text editor and SE, using SE to preview and adjust the rendered diagram, while fc4-tool cleans up the diagram as you work.
 1. When you’re ready to wrap up:
    1. Paste the diagram source into your text editor and save the YAML file.
    1. Paste the diagram source into SE, hit tab to re-render the diagram, then click the _Export to PNG_ button in the toolbar.

--- a/methodology/toolset.md
+++ b/methodology/toolset.md
@@ -1,22 +1,22 @@
 # 4. The Toolset « The FC4 Methodology
 
-Our current toolset for authoring/editing our diagrams is:
+The current toolset for authoring and editing FC4 diagrams is:
 
 | Tool                                                         | Uses                                                         |
 | ------------------------------------------------------------ | ------------------------------------------------------------ |
 | Any text editor                                              | Creating the diagram files; authoring/editing the semantic contents of the diagrams: the elements, relationships, etc |
 | [Structurizr Express](https://structurizr.com/help/express)  | Graphical authoring/editing the positioning of the elements; rendering the diagrams |
-| FC4C (see below) | Reformatting and normalizing the source of the diagrams so they’re diffable and easier to edit; snapping elements to a virtual grid |
+| fc4-tool | Reformatting and normalizing the source of the diagrams so they’re diffable and easier to edit; snapping elements to a virtual grid |
 
-## FC4C
+## fc4-tool
 
-[This tool](https://github.com/FundingCircle/fc4c/) was created because when one uses Structurizr Express (SE) to position the elements of a diagram, SE regenerates the diagram source YAML in such a way that the YAML becomes noisy and the sorting can change. This makes the source harder to work with in a text editor and impossible to usefully diff from revision to revision — and without useful diffing it’s very difficult to do effective peer review.
+fc4-tool was created because when one uses Structurizr Express (SE) to position the elements of a diagram, SE regenerates the diagram source YAML in such a way that the YAML becomes noisy and the sorting can change. This makes the source harder to work with in a text editor and impossible to usefully diff from revision to revision — and without useful diffing it’s very difficult to do effective peer review.
 
-So FC4C processes the YAML: cleans it up, applies a stable sort to all properties, removes empty properties, etc — so as to ensure that the changes applied in each revision are very small and specific and all extraneous changes are filtered out. This will hopefully enable effective peer review of revisions to the diagrams.
+So fc4-tool processes the YAML: cleans it up, applies a stable sort to all properties, removes empty properties, etc — so as to ensure that the changes applied in each revision are very small and specific and all extraneous changes are filtered out. This will hopefully enable effective peer review of revisions to the diagrams.
 
-FC4C also “snaps” the elements and vertices in a diagram to a virtual grid.
+fc4-tool also “snaps” the elements and vertices in a diagram to a virtual grid.
 
-The functionality of FC4C may expand over time to include additional features to assist with authoring and maintaining FC4 diagrams.
+The functionality of fc4-tool may expand over time to include additional features to assist with authoring and maintaining FC4 diagrams.
 
 ----
 

--- a/tool/README.md
+++ b/tool/README.md
@@ -44,7 +44,7 @@ As explained in [The Authoring Workflow](https://fundingcircle.github.io/fc4-fra
 
 > 1. In your text editor: either create a new diagram source file or open an existing diagram source file
 > 1. In a terminal, in your `fc4` working dir, run `cd tool && ./wcb`
->    1. This starts a background process that will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
+>    1. This starts the tool in a mode wherein it will watch your clipboard for diagram source YAML and process (clean up) that YAML when it sees that it’s been changed.
 > 1. In your text editor, add/revise elements and relationships, then select-all and cut the diagram source from your editor into your system clipboard.
 >    1. This will cause fc4-tool to process the contents of your clipboard.
 > 1. Switch to [Structurizr Express](https://structurizr.com/help/express) (SE) » paste the source into the YAML textarea » press tab to blur the textarea


### PR DESCRIPTION
As per #58, in #59 the tool was been renamed from FC4C to fc4-tool. This updates the methodology accordingly.